### PR TITLE
Minor code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dummy-par
+dummy-sing
+plant
+qubo

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(filter par,$(MAKECMDGOALS)),)
   DUM0:= dummy-par
   DUM1:= dummy-sing
 else
-  CFLAGS:= $(CFLAGS) -fopenmp -DPARALLEL
+  CFLAGS:= $(CFLAGS) -fopenmp
   DUM0:= dummy-sing
   DUM1:= dummy-par
 endif

--- a/qubo.c
+++ b/qubo.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -5,9 +6,6 @@
 #include <math.h>
 #include <getopt.h>
 #include <assert.h>
-#ifdef PARALLEL
-#include <omp.h>
-#endif
 
 #include "normal.c"
 
@@ -651,7 +649,7 @@ int checksym(void){// Checks if symmetric (true if couplings equivalent to no ex
   return 1;
 }
 
-int gcd(x,y){
+int gcd(int x,int y){
   if(x<0)x=-x;
   if(y<0)y=-y;
   if(y==0)return x;
@@ -2144,7 +2142,7 @@ int fullexhaust(){
       } 
       mul0=nok[enc(c,r,0)];
       mul1=nok[encp(c-1,r,0)]*nok[enc(c,r,1)];
-#ifdef PARALLEL
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
       for(br=0;br<bm;br++){
@@ -2227,7 +2225,7 @@ int fullexhaust(){
           pre2[bc0][s0]=QB(c,r,1,2,s,bc);
         }
       }
-#ifdef PARALLEL
+#ifdef _OPENMP
 #pragma omp parallel for
 #endif
       for(br=0;br<bm;br++){// br = state of non-c columns


### PR DESCRIPTION
- Replace "#ifdef PARALLEL" with "#ifdef _OPENMP".  The latter is automatically defined when -fopenmp is specified (part of the OpenMP standard).
- Remove "#include <omp.h>", which is needed only when omp_*() functions are called, which they're not.
- Specify the types of gcd()'s arguments.
- Define _GNU_SOURCE to ensure PRNG functions are properly prototyped.
- Include a .gitignore file.
